### PR TITLE
[Comp][Ingredient] Component params extend object, better coverage for params

### DIFF
--- a/src/models/__spec__/component-ingredient.class.spec.ts
+++ b/src/models/__spec__/component-ingredient.class.spec.ts
@@ -46,6 +46,26 @@ describe('Class: Component Ingredient', () => {
         expect(actual.component).toBeTruthy();
     });
 
+    it('should be able to pass in params to the factory', () => {
+        const el = document.createElement('div');
+        el.setAttribute('data-test', 'testing');
+
+        const ingredient = new ComponentIngredient(el, new ViviComponentFactory(MockWithChildrenComponent));
+        expect(ingredient.params).toBeTruthy();
+        expect(ingredient.params.hasOwnProperty('test')).toBeTruthy();
+        expect(ingredient.params['test']).toEqual('testing');
+    });
+
+    it('should be able to pass in params with camelCasing to the factory', () => {
+        const el = document.createElement('div');
+        el.setAttribute('data-test-test', 'testing');
+
+        const ingredient = new ComponentIngredient(el, new ViviComponentFactory(MockWithChildrenComponent));
+        expect(ingredient.params).toBeTruthy();
+        expect(ingredient.params.hasOwnProperty('testTest')).toBeTruthy();
+        expect(ingredient.params['testTest']).toEqual('testing');
+    });
+
     it('load should append element', () => {
         const actual = mockIngredient();
 

--- a/src/models/component-params.class.ts
+++ b/src/models/component-params.class.ts
@@ -1,5 +1,6 @@
-export abstract class ComponentParams {
+export abstract class ComponentParams extends Object {
     constructor(obj?: Object) {
+        super();
         if (obj) {
             Object.keys(obj).forEach(key => {
                 this[key] = obj[key];


### PR DESCRIPTION
Closes #16 
Turns out dataset allows for camelCasing, but the data needs to be set via kabob-case

Reference: https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/dataset
