### PR TITLE
Removed error throw from listener

### DIFF
--- a/src/events/__spec__/listener.spec.ts
+++ b/src/events/__spec__/listener.spec.ts
@@ -20,14 +20,14 @@ describe('Class: Listener', () => {
     });
 
     describe('add() / remove()', () => {
-        it('Add should throw an error if there is no element', () => {
+        it('Add should not do anything if there is no element', () => {
             const listener = new Listener('test', null, null);
-            expect(() => { listener.add(); }).toThrowError('No element found to add listener to');
+            expect(() => { listener.add(); }).not.toThrowError();
         });
 
-        it('Remove should throw an error if there is no element', () => {
+        it('Remove should not do anything if there is no element', () => {
             const listener = new Listener('test', null, null);
-            expect(() => { listener.remove(); }).toThrowError('No element found to remove listener from');
+            expect(() => { listener.remove(); }).not.toThrowError();
         });
 
         it('Add should add an event listener to the element', () => {
@@ -70,7 +70,7 @@ describe('Class: Listener', () => {
                 element.dispatchEvent(new KeyboardEvent('keypress', { 'key': 'Enter' }));
             });
             
-            it('enter - should nto trigger call back on keypress:anything else', () => {
+            it('enter - should not trigger call back on keypress:anything else', () => {
                 const element = document.createElement('button');
                 const listener = new Listener(EventTypes.enter, element, () => {
                     throw 'If you are seeing this, this test is failing.';

--- a/src/events/listener.class.ts
+++ b/src/events/listener.class.ts
@@ -50,12 +50,12 @@ export class Listener {
     }
 
     add() {
-        if (!this.element) throw 'No element found to add listener to';
+        if (!this.element) return;
         this.element.addEventListener(this.type, this.callback, this.options);
     }
 
     remove() {
-        if (!this.element) throw 'No element found to remove listener from';
+        if (!this.element) return;
         this.element.removeEventListener(this.type, this.callback, this.options);
     }
 }


### PR DESCRIPTION
### Linked Issues:
Fixes #36

### Changes:
- Listener class no longer throws an error if there's no element when added or removed from a non-existent element.

### Type:
This is a bugfix update.
