### PR TITLE
Template loads children, also replaces existing elements

### DIFF
--- a/src/meta/mocker.ts
+++ b/src/meta/mocker.ts
@@ -94,7 +94,7 @@ export class Mocker {
         }
 
         if (!options.doNotAppend) {
-            comp.append(null, options.doNotLoad);
+            comp.append(null, null, options.doNotLoad);
         }
         return comp;
     }

--- a/src/models/__spec__/component.class.spec.ts
+++ b/src/models/__spec__/component.class.spec.ts
@@ -66,7 +66,7 @@ describe('Class: Component', () => {
 
             component.append();
 
-            expect(component.parent).toEqual(document.body);
+            expect(component.parentElement).toEqual(document.body);
             expect(component.element).toBeTruthy();
         });
 
@@ -77,9 +77,14 @@ describe('Class: Component', () => {
 
             component.append(mockParent);
 
-            expect(component.parent).toEqual(mockParent);
+            expect(component.parentElement).toEqual(mockParent);
             const template = document.getElementById(component.id);
             expect(template.innerHTML).toEqual(component.template);
+        });
+
+        it('should replace existing node in template', () => {
+            const component = mock.createMock({ template: '<mock></mock>'});
+            expect(component.element.children.length).toEqual(1);
         });
 
         it('should automatically add elements and bind them', () => {
@@ -108,12 +113,20 @@ describe('Class: Component', () => {
 
             expect(component[testEl.propertyKey]).toBeTruthy();
         });
+
+        it('should run loadAll and load children', () => {
+            const errorSpy = spyOn(console, 'error');
+            const comp = mock.createMock({ template: '<mock></mock>'});
+            expect(errorSpy).not.toHaveBeenCalled();
+            expect(comp.children[0]).toBeTruthy();
+            expect(comp.children[0].element).toBeTruthy();
+        });
     });
 
     describe('loadall', () => {
-        it('should throw an error if component is not appended', () => {
+        it('should throw a warning if element is not found', () => {
             const comp = mock.createMock({ doNotAppend: true });
-            const errorSpy = spyOn(console, 'error');
+            const errorSpy = spyOn(console, 'warn');
             comp.loadAll();
 
             expect(errorSpy).toHaveBeenCalled();
@@ -139,7 +152,7 @@ describe('Class: Component', () => {
             component.detach();
 
             expect(component.element.isConnected).toBeFalsy();
-            expect(component.parent).toBeNull();
+            expect(component.parentElement).toBeNull();
         });
     });
 

--- a/src/services/engine/__spec__/components.spec.ts
+++ b/src/services/engine/__spec__/components.spec.ts
@@ -48,5 +48,13 @@ describe('Component Parse Engine', () => {
 
             expect(actual.length).toEqual(2);
         });
+
+        it('should not throw console error when loading chilren after parse', () => {
+            const errorSpy = spyOn(console, 'error');
+            const comp = mock.createMock({ template: '<mock></mock>'});
+
+            expect(errorSpy).not.toHaveBeenCalled();
+            expect(comp.children[0].element).toBeTruthy();
+        });
     });
 });

--- a/src/services/engine/components.ts
+++ b/src/services/engine/components.ts
@@ -26,10 +26,10 @@ export class ParseComponents {
             const name = reg.slice(0, reg.lastIndexOf('Component'));
             const els = node.querySelectorAll(name.toLowerCase());
             for (let i = 0; i < els.length; i++) {
-                const el = els.item(i);
+                const el = els.item(i) as HTMLElement;
                 const factory = this.factoryService.getFactoryByString(reg) as ViviComponentFactory<Component>;
-                const child = factory.create((<HTMLElement>el).dataset);
-                child.append(el.parentElement, true);
+                const child = factory.create((el).dataset);
+                child.append(el.parentElement, el, true);
                 recipe.push(child);
             }
         });


### PR DESCRIPTION
### Linked Issues:
Fixes #47 
Fixes #27 

### Changes:
- Component: Parent renamed to ParentElement to not confuse with generic "parent"
- Elements replace their user template version.
- Element is assigned in loadAll, which having it in append was causing this bug

### Type:
This is a bugfix update.
