### PR TITLE
Separate fn to handle getting template name

### DIFF
--- a/src/helpers/__spec__/get-el-name-from-component.spec.ts
+++ b/src/helpers/__spec__/get-el-name-from-component.spec.ts
@@ -1,0 +1,21 @@
+import { GetElNameFromComponent } from '../get-el-name-from-component';
+
+describe('GetElNameFromClass', () => {
+    it('should get a simple component name', () => {
+        const actual = GetElNameFromComponent('MockComponent');
+
+        expect(actual).toEqual('mock');
+    });
+
+    it('should get complex component name', () => {
+        const actual = GetElNameFromComponent('MyCoolComponent');
+
+        expect(actual).toEqual('my-cool');
+    });
+
+    it('should get multiword complex component name', () => {
+        const actual = GetElNameFromComponent('MyReallyReallyCoolComponent');
+
+        expect(actual).toEqual('my-really-really-cool');
+    });
+});

--- a/src/helpers/get-el-name-from-component.ts
+++ b/src/helpers/get-el-name-from-component.ts
@@ -1,0 +1,3 @@
+export function GetElNameFromComponent(name: string): string {
+    return name.replace('Component', '').replace(/\B(?=[A-Z])/g, '-').toLowerCase();
+}

--- a/src/models/component.class.ts
+++ b/src/models/component.class.ts
@@ -5,6 +5,7 @@ import { getElements } from '../decorators/element.decorator';
 import { ModuleFactory, ViviComponentFactory } from 'factory';
 import { ParseEngineService } from '../services/parse-engine.service';
 import { FactoryService } from '../services/factory.service';
+import { GetElNameFromComponent } from '../helpers/get-el-name-from-component';
 
 export abstract class Component {
     id: string;
@@ -38,7 +39,7 @@ export abstract class Component {
         // Get template and style file
 
         // Turns a name like "SearchBarComponent" to look for "search-bar.component.xyz"
-        this.componentName = this.constructor.name.replace('Component', '').replace(/\B(?=[A-Z])/, '-').toLowerCase();
+        this.componentName = GetElNameFromComponent(this.constructor.name);
         /*
             @todo Allow for components to grab the module folder / multiple modules
             @body Currently file structure is root/component-name/component-name.component.xyz. Allow for components to be in directories based off of the module

--- a/src/services/engine/components.ts
+++ b/src/services/engine/components.ts
@@ -1,6 +1,7 @@
 import { Component } from '../../models/component.class';
 import { FactoryService } from '../factory.service';
 import { ViviComponentFactory } from '../../factory';
+import { GetElNameFromComponent } from '../../helpers/get-el-name-from-component';
 
 export class ParseComponents {
     constructor(private factoryService: FactoryService) {
@@ -23,8 +24,8 @@ export class ParseComponents {
         const recipe = new Array<Component>();
         this.factoryService.module.getComponentRegistry().forEach(reg => {
             // Strip 'Component' off of name
-            const name = reg.slice(0, reg.lastIndexOf('Component'));
-            const els = node.querySelectorAll(name.toLowerCase());
+            const name = GetElNameFromComponent(reg);
+            const els = node.querySelectorAll(name);
             for (let i = 0; i < els.length; i++) {
                 const el = els.item(i) as HTMLElement;
                 const factory = this.factoryService.getFactoryByString(reg) as ViviComponentFactory<Component>;


### PR DESCRIPTION
### Linked Issues:
Fixes #28 
Fixes #30 

### Changes:
- Added tests for regex logic
- Moved out to own file to be used in the parse engine (#30)
- Added global flag to regex to match more than one word (#28)

### Type:
This is a bugfix update.
