### PR TITLE
Components don't reinstance for grandparents

### DIFF
--- a/src/services/engine/__spec__/components.spec.ts
+++ b/src/services/engine/__spec__/components.spec.ts
@@ -1,6 +1,8 @@
 import { ParseComponents } from '../components';
 import { Mocker } from '../../../meta/mocker';
 import { FactoryService } from '../../factory.service';
+import { Component } from '../../../models';
+import { ModuleFactory } from '../../../factory';
 
 describe('Component Parse Engine', () => {
     const mock = new Mocker();
@@ -12,7 +14,7 @@ describe('Component Parse Engine', () => {
 
     it('should init', () => {
         const parse = new ParseComponents(null);
-        
+
         expect(parse).toBeTruthy();
     });
 
@@ -36,25 +38,58 @@ describe('Component Parse Engine', () => {
         it('should return components of chilren', () => {
             const comp = mock.createMock({ template: '<mock></mock>' });
 
-            const actual = parse.parseComponents(comp.parsedNode);
-
-            expect(actual.length).toBeTruthy();
+            expect(comp.children.length).toEqual(1);
         });
 
         it('should return multiple components of children', () => {
             const comp = mock.createMock({ template: '<mock></mock><mock></mock>' });
 
-            const actual = parse.parseComponents(comp.parsedNode);
-
-            expect(actual.length).toEqual(2);
+            expect(comp.children.length).toEqual(2);
         });
 
         it('should not throw console error when loading chilren after parse', () => {
             const errorSpy = spyOn(console, 'error');
-            const comp = mock.createMock({ template: '<mock></mock>'});
+            const comp = mock.createMock({ template: '<mock></mock>' });
 
             expect(errorSpy).not.toHaveBeenCalled();
             expect(comp.children[0].element).toBeTruthy();
+        });
+
+        it('grandchildren should not try to rerender', () => {
+            let counter = 0;
+            class GrandparentComponent extends Component {
+                constructor() {
+                    super();
+                    this.template = '<parent></parent>';
+                    counter++;
+                }
+            }
+
+            class ParentComponent extends Component {
+                constructor() {
+                    super();
+                    this.template = '<child></child>';
+                    counter++;
+                }
+            }
+
+            class ChildComponent extends Component {
+                constructor() {
+                    super();
+                    this.template = '<span>Test</span>';
+                    counter++;
+                }
+            }
+
+            const module = new ModuleFactory({
+                componentConstructors: [
+                    { constructor: GrandparentComponent },
+                    { constructor: ParentComponent },
+                    { constructor: ChildComponent }
+                ],
+                rootComponent: GrandparentComponent
+            });
+            expect(counter).toEqual(3);
         });
     });
 });

--- a/src/services/engine/components.ts
+++ b/src/services/engine/components.ts
@@ -28,10 +28,12 @@ export class ParseComponents {
             const els = node.querySelectorAll(name);
             for (let i = 0; i < els.length; i++) {
                 const el = els.item(i) as HTMLElement;
-                const factory = this.factoryService.getFactoryByString(reg) as ViviComponentFactory<Component>;
-                const child = factory.create((el).dataset);
-                child.append(el.parentElement, el, true);
-                recipe.push(child);
+                if (!el.id) {
+                    const factory = this.factoryService.getFactoryByString(reg) as ViviComponentFactory<Component>;
+                    const child = factory.create((el).dataset);
+                    child.append(el.parentElement, el, true);
+                    recipe.push(child);
+                }
             }
         });
 


### PR DESCRIPTION
### Linked Issues:
Fixes #53 

### Changes:
- Components don't re instance for grandparents

### Type:
This is a bugfix update.
