### PR TITLE
fix(node-tree): component append behavior better reflects node-tree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ jobs:
     # Define the release stage that runs semantic-release
     - stage: release
       node_js: lts/*
-      script: skip
       deploy:
         provider: script
         skip_cleanup: true

--- a/README.md
+++ b/README.md
@@ -6,12 +6,16 @@
 
 # Vivi
 
-A lightweight component-focused Javascript framework. Vivi is currently still in it's early stages, so breaking changes are more common. This package uses semantic versioning, so major breaking changes is generally reserved for major versions.
+A lightweight component-focused Javascript framework. Vivi is currently still in it's early stages, so breaking changes are more common. This package uses semantic versioning, so breaking changes will result major version updates.
 
 ---
 
-## v3 Update:
-v3 has been released! Some of the new changes:
+## Announcements
+### Versioning
+Vivi is moving over to true automated semantic releases, so future update announcements and milestones will be groups of major feature updates and fixes.
+
+### Node Tree Milestone Update (Previously v3):
+Node tree milestone is complete and has been released! Some of the new changes:
 - Dynamic loading for child components from the template, like adding a list of components based off an array
 - Easier loading for child components from the component class
 - Lots of component and template-related bugfixes! Yay!
@@ -30,9 +34,8 @@ Check out the [Issues](https://github.com/CassandraSpruit/Vivi/issues) page. In 
 ### How to Contribute
 1. Fork this repository
 2. Create a branch: ```git checkout -b <branch_name>```
-    - There's no standard for branch names, but if it's connected to an issue try starting with i(issue-number)_branch-name. Ex: i17_My-cool-branch-name
-3. Make your changes and commit them: ```git commit -m '<commit_message>'```
-    - It's not enforced, but please remeber to write unit tests, if applicable.
+3. Make your changes and commit using : ```npm run commit```
+    - Please remeber to write tests, if applicable.
     - You can run tests by running ```npm run test```. Or if you have jest installed, you can run it for specific files.
     - Note: There seems to be a bug with running code coverage along with debugging in VS Code. You can turn off coverage in the jest.config.js file by commenting "collectCoverage: true" out or setting it to false.
 4. Push to the original branch: ```git push origin https://github.com/CassandraSpruit/Vivi.git```

--- a/README.md
+++ b/README.md
@@ -11,13 +11,11 @@ A lightweight component-focused Javascript framework. Vivi is currently still in
 ---
 
 ## v3 Update:
-Milestone for v3 has started! Things to look forward to:
-- Dynamic loading for child components from the template
+v3 has been released! Some of the new changes:
+- Dynamic loading for child components from the template, like adding a list of components based off an array
 - Easier loading for child components from the component class
 - Lots of component and template-related bugfixes! Yay!
 - Smaller package size!
-
-Check out progress on the [milestones page](https://github.com/CassandraSpruit/Vivi/milestones).
 
 ---
 ## Installation and Gettings Started

--- a/src/factory/__spec__/module-factory.spec.ts
+++ b/src/factory/__spec__/module-factory.spec.ts
@@ -5,7 +5,7 @@ import { MockService, MockWithPrereqService } from '../../models/__mocks__/servi
 describe('Class: Module Factory', () => {
     const minimumConstructor = () => {
         return new ModuleFactory({
-            componentConstructors: [{constructor: MockComponent}],
+            componentConstructors: [{ constructor: MockComponent }],
             rootComponent: MockComponent
         });
     }
@@ -85,7 +85,7 @@ describe('Class: Module Factory', () => {
         it('get should return component, if created', () => {
             // Create component
             const factory = vivi.getFactory(MockComponent) as ComponentFactory;
-            factory.create(null, null, true);
+            factory.create(null, null, { isRoot: true });
             const actual = vivi.get(MockComponent);
 
             expect(actual instanceof MockComponent).toBeTruthy();

--- a/src/factory/__spec__/service-factory.class.spec.ts
+++ b/src/factory/__spec__/service-factory.class.spec.ts
@@ -42,17 +42,21 @@ describe('ServiceFactory', () => {
         it('should return service if id is provided', () => {
             const service = factory.create();
 
-            const actual = factory.get(service.id);
-
-            expect(actual).toBeTruthy();
+            expect(factory.get(service.id)).toBeTruthy();
         });
 
-        it('should return the first service if no id is provided', () => {
+        it('should return null if no id is provided and no services have been created', () => {
             const toBeRemoved = factory.get();
             factory.destroy(toBeRemoved.id);
 
-            const actual = factory.get();
-            expect(actual).toBeNull();
+            expect(factory.get()).toBeNull();
+        });
+
+        it('should return latest service created if no ide is provided', () => {
+            const serviceA = factory.create();
+            const serviceB = factory.create();
+
+            expect(factory.get()).toEqual(serviceB);
         });
     });
 

--- a/src/factory/component-factory.class.ts
+++ b/src/factory/component-factory.class.ts
@@ -1,6 +1,7 @@
 import { ServiceFactory } from './service-factory.class';
 import { Component, Service } from '../models';
 import { NodeTreeService } from '../services';
+import { NodeTree } from '../models/node-tree';
 
 export class ComponentFactory<T extends Component = Component> {
     private components: Map<string, T> = new Map<string, T>();
@@ -14,14 +15,14 @@ export class ComponentFactory<T extends Component = Component> {
         //
     }
 
-    createRoot(nodeTreeService: NodeTreeService): T {
+    createRoot(nodeTreeService: NodeTreeService) {
         this.nodeTreeService = nodeTreeService;
-        const comp = this.create(null, null, true);
+        const comp = this.create(null, null, { parentEl: document.body, doNotLoad: true, isRoot: true });
         this.nodeTreeService.setRoot(comp);
-        return comp;
+        this.nodeTreeService.applicationTree.load();
     }
 
-    create(parent: Component, data?: Object, isRoot?: boolean): T {
+    create(parent: Component, data?: Object, options?: { parentEl?: HTMLElement, replaceEl?: HTMLElement, doNotLoad?: boolean, isRoot?: boolean }): T {
         // Create
         const component = new this.constructor(...this.services.map(service => service.get()));
         component.setData(this.counter, data);
@@ -30,35 +31,45 @@ export class ComponentFactory<T extends Component = Component> {
         // Record in map and tree
         this.components.set(component.id, component);
 
-        if (!isRoot) {
-            this.nodeTreeService.addComponent(parent, component);
+        let node: NodeTree;
+        if (!options || !options.isRoot) {
+            node = this.nodeTreeService.addComponent(parent, component);
+        }
+
+        if (options && options.parentEl) {
+            component.append(options.parentEl, options.replaceEl);
+
+            if (!options.doNotLoad) {
+                node.load();
+            }
         }
 
         return component;
     }
 
+    detach(id: string): NodeTree {
+        const comp = this.get(id);
+        if (!comp) return;
+
+        // Remove from tree and return resulting node to re-attach later
+        return this.nodeTreeService.detachComponent(comp);
+    }
+
     destroy(id: string) {
         const component = this.get(id);
+        if (!component) return;
 
-        if (!component) {
-            console.error(`${this.constructor.name}: No component found with id: ${id}`);
+        // Make sure this isn't the root component
+        if (id === this.nodeTreeService.applicationTree.component.id) {
+            // console.info(`Destroy called on Root Component ${id}. The component was not destroyed.`);
             return;
         }
 
-        // Run cleanup
-        component.destroy();
-
-        // Remove from the DOM
-        const node = document.getElementById(id);
-        if (node) {
-            node.remove();
-        }
+        // Remove from tree and DOM
+        this.nodeTreeService.removeComponent(component);
 
         // Remove from the map
         this.components.delete(id);
-
-        // Remove from tree
-        this.nodeTreeService.removeComponent(component);
     }
 
     destroyAll() {
@@ -67,12 +78,15 @@ export class ComponentFactory<T extends Component = Component> {
 
     get(id?: string): T {
         if (id) {
-            // @todo: ComponentFactory - Throw error if id doesn't exist
-            return this.components.get(id);
+            const comp = this.components.get(id);
+            if (!comp) {
+                console.error(`${this.constructor.name}: No component found with id: ${id}`);
+                return;
+            }
+            return comp;
         } else {
             // @todo: ComponentFactory - throw error (or warning) if this.components.length is 0
-            // @todo: ComponentFactory - Grab the last component created
-            return Array.from(this.components.values())[0] || null;
+            return Array.from(this.components.values())[this.components.size - 1] || null;
         }
     }
 }

--- a/src/factory/module-factory.ts
+++ b/src/factory/module-factory.ts
@@ -58,8 +58,8 @@ export class ModuleFactory {
 
         // Mount root component
         const rootFactory = this.getFactory(module.rootComponent) as ComponentFactory;
-        const rootComp = rootFactory.createRoot(nodeTree);
-        rootComp.append();
+        // @todo Add ability to make root component append to a user-specified node
+        rootFactory.createRoot(nodeTree);
 
         // Initialize
         this.start();

--- a/src/factory/service-factory.class.ts
+++ b/src/factory/service-factory.class.ts
@@ -31,7 +31,7 @@ export class ServiceFactory<T extends Service = Service> {
         if (id) {
             return this.instances.get(id);
         } else {
-            return Array.from(this.instances.values())[0] || null;
+            return Array.from(this.instances.values())[this.instances.size - 1] || null;
         }
     }
 

--- a/src/meta/__spec__/mocker.spec.ts
+++ b/src/meta/__spec__/mocker.spec.ts
@@ -146,7 +146,8 @@ describe('Mocker', () => {
         });
 
         it('doNotLoad - should not automatically load component if true', () => {
-            const loadSpy = spyOn(MockComponent.prototype, 'loadAll');
+            const nodeTreeService = mock.module.get(NodeTreeService) as NodeTreeService;
+            const loadSpy = spyOn(nodeTreeService, 'loadComponent');
             mock.createMock({ doNotLoad: true });
 
             expect(loadSpy).not.toHaveBeenCalled();
@@ -165,13 +166,13 @@ describe('Mocker', () => {
             mock.clearMocks();
         });
 
-        it('should clear all existsing mocks', () => {
+        it('should clear all existsing mocks except the root component', () => {
             const mock = new Mocker();
             mock.createMock();
             mock.createMock();
             mock.clearMocks();
 
-            expect(mock.getFactory().get()).toBeFalsy();
+            expect(mock.getFactory().get()).toEqual(mock.rootComp);
         });
     });
 });

--- a/src/models/__spec__/component.class.spec.ts
+++ b/src/models/__spec__/component.class.spec.ts
@@ -30,13 +30,6 @@ describe('Class: Component', () => {
     });
 
     describe('append', () => {
-        it('should create a copy of the original node', () => {
-            const component = mock.createMock();
-
-            expect(component.ogNode).toBeTruthy();
-            expect(component.ogNode.id).toEqual(component.id);
-        });
-
         it('should parse node', () => {
             const data = { name: 'test ' };
             const comp = mock.createMock({ data });
@@ -61,13 +54,13 @@ describe('Class: Component', () => {
             expect(styleTags.length).toEqual(1);
         });
 
-        it('should append to document body if parent is not provided', () => {
+        it('should throw error if parent is not provided', () => {
             const component = mock.createMock();
+            const errorSpy = spyOn(console, 'error');
 
-            component.append();
+            component.append(null);
 
-            expect(component.parentElement).toEqual(document.body);
-            expect(component.element).toBeTruthy();
+            expect(errorSpy).toHaveBeenCalled();
         });
 
         it('should append to parent', () => {
@@ -77,13 +70,14 @@ describe('Class: Component', () => {
 
             component.append(mockParent);
 
-            expect(component.parentElement).toEqual(mockParent);
+            expect(mockParent.children.length).toBeTruthy();
             const template = document.getElementById(component.id);
             expect(template.innerHTML).toEqual(component.template);
         });
 
         it('should replace existing node in template', () => {
             const component = mock.createMock({ template: '<mock></mock>'});
+
             expect(component.element.children.length).toEqual(1);
         });
 
@@ -91,12 +85,13 @@ describe('Class: Component', () => {
             const el = { propertyKey: 'test', selector: 'button.test', handlerFnName: 'testClick', eventType: EventTypes.click };
             const component = mock.createMock({
                 elements: [el],
-                template: `<button class="test"></button>`
+                template: `<button class="test"></button>`,
+                doNotLoad: true
             });
 
             const mockClick = jest.fn();
             component[el.handlerFnName] = mockClick;
-            component.append();
+            component.startLoad();
             component[el.propertyKey].click();
 
             expect(mockClick.mock.calls.length).toBe(1);
@@ -109,8 +104,6 @@ describe('Class: Component', () => {
                 template: `<span class="test"></span>`
             });
 
-            component.append();
-
             expect(component[testEl.propertyKey]).toBeTruthy();
         });
     });
@@ -119,7 +112,7 @@ describe('Class: Component', () => {
         it('should throw a warning if element is not found', () => {
             const comp = mock.createMock({ doNotAppend: true });
             const errorSpy = spyOn(console, 'warn');
-            comp.loadAll();
+            comp.startLoad();
 
             expect(errorSpy).toHaveBeenCalled();
         });
@@ -128,15 +121,10 @@ describe('Class: Component', () => {
     describe('detach', () => {
         it('should remove element from DOM', () => {
             const component = mock.createMock();
-            const mockParent = document.createElement('parent');
-            document.body.appendChild(mockParent);
-
-            component.append(mockParent);
 
             component.detach();
 
             expect(component.element.isConnected).toBeFalsy();
-            expect(component.parentElement).toBeNull();
         });
     });
 
@@ -206,8 +194,6 @@ describe('Class: Component', () => {
                 data: { name: 'fluffy' },
                 template: `<span v-innerHTML="this.name"></span>`
             });
-
-            component.append();
 
             const newName = 'bunny';
             component.data = { name: newName };

--- a/src/models/__spec__/node-tree.class.spec.ts
+++ b/src/models/__spec__/node-tree.class.spec.ts
@@ -27,6 +27,27 @@ describe('NodeTree', () => {
         });
     });
 
+    describe('removeChild', () => {
+        it('should remove child and return removed node', () => {
+            const comp = mock.createMock();
+            const child = mock.createMock();
+            const tree = new NodeTree(comp);
+            const addedNode = tree.addChild(child);
+            const removedNode = tree.removeChild(child);
+
+            expect(removedNode).toEqual(addedNode);
+        });
+
+        it('should return null if child is not found', () => {
+            const comp = mock.createMock();
+            const child = mock.createMock();
+            const tree = new NodeTree(comp);
+            const removedNode = tree.removeChild(child);
+
+            expect(removedNode).toBeFalsy();
+        });
+    });
+
     describe('findChild', () => {
         it('should find child if exists', () => {
             const comp = mock.createMock();
@@ -84,6 +105,100 @@ describe('NodeTree', () => {
             const found = tree.findChild(child.id, false, true);
 
             expect(found).toBeFalsy();
+        });
+    });
+    
+    describe('findParentOf', () => {
+        it('should return itself if it is the parent', () => {
+            const comp = mock.createMock();
+            const child = mock.createMock();
+            const tree = new NodeTree(comp);
+            tree.addChild(child);
+            
+            expect(tree.findParentOf(child.id)).toEqual(tree);
+        });
+
+        it('should return parent if parent exists', () => {
+            const comp = mock.createMock();
+            const child = mock.createMock();
+            const grandChild = mock.createMock();
+            const tree = new NodeTree(comp);
+            const childNode = tree.addChild(child);
+            childNode.addChild(grandChild);
+            
+            expect(tree.findParentOf(grandChild.id)).toEqual(childNode);
+        });
+
+        it('should return null if there is no parent', () => {
+            const comp = mock.createMock();
+            const sassyChild = mock.createMock();
+            const tree = new NodeTree(comp);
+
+            expect(tree.findParentOf(sassyChild.id)).toBeFalsy();
+        });
+    });
+
+    describe('hasChild', () => {
+        it('should return true if child exists', () => {
+            const comp = mock.createMock();
+            const child = mock.createMock();
+            const tree = new NodeTree(comp);
+            tree.addChild(child);
+
+            expect(tree.hasChild(child.id)).toBeTruthy();
+        });
+
+        it('should return false if child does not exist', () => {
+            const comp = mock.createMock();
+            const child = mock.createMock();
+            const tree = new NodeTree(comp);
+
+            expect(tree.hasChild(child.id)).toBeFalsy();
+        });
+    });
+
+    describe('load', () => {
+        it('should load component', () => {
+            const comp = mock.createMock();
+            const loadSpy = spyOn(comp, 'startLoad');
+            const tree = new NodeTree(comp);
+
+            tree.load();
+
+            expect(loadSpy).toHaveBeenCalled();
+        });
+
+        it('should laod children', () => {
+            const comp = mock.createMock();
+            const child = mock.createMock();
+            const loadChildSpy = spyOn(child, 'startLoad');
+            const tree = new NodeTree(comp);
+            tree.addChild(child);
+
+            tree.load();
+
+            expect(loadChildSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('destroy', () => {
+        it('should trigger component destroy', () => {
+            const comp = mock.createMock();
+            const tree = new NodeTree(comp);
+            
+            tree.destroy();
+
+            expect(comp.element.isConnected).toBeFalsy();
+        });
+
+        it('should destroy children', () => {
+            const comp = mock.createMock();
+            const tree = new NodeTree(comp);
+            const child = mock.createMock();
+            tree.addChild(child);
+            tree.destroy();
+
+            expect(child.element.isConnected).toBeFalsy();
         });
     });
 });

--- a/src/models/node-tree.ts
+++ b/src/models/node-tree.ts
@@ -15,6 +15,12 @@ export class NodeTree {
         return node;
     }
 
+    removeChild(comp: Component): NodeTree {
+        const foundIndex = this.children.findIndex(child => child.component.id === comp.id);
+        if (foundIndex === -1) return;
+        return this.children.splice(foundIndex, 1)[0];
+    }
+
     findChild(id: string, deepSearch?: boolean, returnNode?: boolean): Component | NodeTree {
         const child = this.children.find(child => {
             return deepSearch ? 
@@ -25,7 +31,23 @@ export class NodeTree {
         return child ? child.component : null;
     }
 
+    findParentOf(id: string): NodeTree {
+        if (this.hasChild(id)) return this;
+        return this.children.find(child => child.findParentOf(id));
+    }
+
+    hasChild(id: string): boolean {
+        return !!this.children.find(child => child.component.id === id);
+    }
+
+    load() {
+        this.component.startLoad();
+        this.children.forEach(child => child.load());
+    }
+
     destroy() {
         this.children.forEach(child => child.destroy());
+        this.children = [];
+        this.component.destroy();
     }
 }

--- a/src/services/__spec__/parse-engine.service.spec.ts
+++ b/src/services/__spec__/parse-engine.service.spec.ts
@@ -8,11 +8,6 @@ describe('Parse Elements', () => {
 
     afterEach(() => {
         mock.clearMocks();
-
-        // Clear the document
-        for (let i = 0; i < document.body.children.length; i++) {
-            document.body.children.item(i).remove();
-        }
     });
 
     it('should work', () => {

--- a/src/services/parse-engine.service.ts
+++ b/src/services/parse-engine.service.ts
@@ -60,8 +60,7 @@ export class ParseEngineService extends Service {
                 if (arr.forEach) {
                     arr.forEach((item, index) => {
                         const factory = this.factoryService.getFactoryByString(componentName);
-                        const newComponent = factory.create(comp, item) as Component;
-                        newComponent.append(el, null, true);
+                        factory.create(comp, item, { parentEl: el, doNotLoad: true });
                     });
                 }
             }
@@ -96,8 +95,7 @@ export class ParseEngineService extends Service {
                 const el = els.item(i) as HTMLElement;
                 if (!el.id) {
                     const factory = this.factoryService.getFactoryByString(reg);
-                    const child = factory.create(comp, (el).dataset) as Component;
-                    child.append(el.parentElement, el, true);
+                    factory.create(comp, (el).dataset, { parentEl: el.parentElement, replaceEl: el, doNotLoad: true});
                 }
             }
         });


### PR DESCRIPTION
Components aside from root append to application root by default instead of document body.

BREAKING CHANGE: CompFactory create and component append are combined. Load logic moved to node
tree. Detach logic moved to node tree. Factory.get() returns the last created, not first.

Closes #79, Closes #78, Fixes #71