### PR TITLE
fix(component): nodeTreeService added to Component class

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -118,6 +118,7 @@ export declare abstract class Component {
     factoryService: FactoryService;
     appEvents: ApplicationEventService;
     engine: ParseEngineService;
+    nodeTreeService: NodeTreeService;
     constructor();
     setData(id: number, data?: Object): void;
     private getUnparsedNode;

--- a/src/models/component.class.ts
+++ b/src/models/component.class.ts
@@ -5,6 +5,7 @@ import { ComponentFactory } from 'factory/component-factory.class';
 import { ParseEngineService } from '../services/parse-engine.service';
 import { FactoryService } from '../services/factory.service';
 import { GetElNameFromComponent } from '../helpers/get-el-name-from-component';
+import { NodeTreeService } from '../services';
 
 export abstract class Component {
     id: string;
@@ -20,12 +21,14 @@ export abstract class Component {
     factoryService: FactoryService;
     appEvents: ApplicationEventService;
     engine: ParseEngineService;
+    nodeTreeService: NodeTreeService;
 
     constructor() {
         // Default Services
-        this.appEvents = (<any>window).vivi.get(ApplicationEventService);
         this.factoryService = (<any>window.vivi.get(FactoryService));
-        this.engine = (<any>window).vivi.get(ParseEngineService);
+        this.appEvents = this.factoryService.getFactory(ApplicationEventService).get();
+        this.engine = this.factoryService.getFactory(ParseEngineService).get();
+        this.nodeTreeService = this.factoryService.getFactory(NodeTreeService).get();
 
         // Get template and style file
 


### PR DESCRIPTION
Added nodeTreeService to be accessible from the component class. Other services on component switched to using the factoryService to grab data to avoid window object.

Fix #85

