### PR TITLE
fix(module): get throws console error + trace, not error message

### DIFF
--- a/src/factory/__spec__/module-factory.spec.ts
+++ b/src/factory/__spec__/module-factory.spec.ts
@@ -1,7 +1,6 @@
-import { ComponentFactory, ServiceFactory, ModuleFactory } from '../';
-import { MockComponent, MockChildComponent } from '../../models/__mocks__/component.class';
+import { ComponentFactory, ModuleFactory, ServiceFactory } from '../';
+import { MockChildComponent, MockComponent } from '../../models/__mocks__/component.class';
 import { MockService, MockWithPrereqService } from '../../models/__mocks__/service.class';
-import { Service } from '../../models';
 
 describe('Class: Module Factory', () => {
     const minimumConstructor = () => {
@@ -78,8 +77,10 @@ describe('Class: Module Factory', () => {
             expect(actual instanceof ServiceFactory).toBeTruthy();
         });
 
-        it('get factory should throw error if no service or component is found', () => {
-            expect(() => { vivi.getFactoryByString('test'); }).toThrowError('No service or component for test');
+        it('get should throw error if no service or component is found', () => {
+            const errorSpy = spyOn(console, 'error');
+            vivi.getFactoryByString('Bad Component Name');
+            expect(errorSpy).toHaveBeenCalled();
         });
     });
 
@@ -106,11 +107,6 @@ describe('Class: Module Factory', () => {
             const actual = vivi.get(MockService);
 
             expect(actual instanceof MockService).toBeTruthy();
-        });
-        
-        it('get should throw error if no service or component is found', () => {
-            class ServiceIsBad extends Service {};
-            expect(() => { vivi.get(ServiceIsBad) }).toThrowError('No service or component for ServiceIsBad');
         });
     });
 

--- a/src/factory/module-factory.ts
+++ b/src/factory/module-factory.ts
@@ -68,15 +68,7 @@ export class ModuleFactory {
     get<T extends Component>(constuctor: new (...args) => T, id?: string): T;
     get<T extends Service>(constuctor: new (...args) => T, id?: string): T;
     get(constuctor: new (...args) => Component | Service, id?: string): Component | Service {
-        const name = constuctor.name;
-        const matches = name.match(/(.*)(Component|Service)$/);
-        if (matches && matches[2] && matches[2] === 'Service') {
-            return this.services.get(name).get(id);
-        }
-        if (matches && matches[2] && matches[2] === 'Component') {
-            return this.components.get(name).get(id);
-        }        
-        throw 'No service or component for ' + name;
+        return this.getFactory(constuctor).get();
     }
 
     getFactory<T extends Component = Component>(constructor: new (...args) => T): ComponentFactory<T>;
@@ -94,7 +86,8 @@ export class ModuleFactory {
         if (matches && matches[2] && matches[2] === 'Component') {
             return this.components.get(name);
         }
-        throw 'No service or component for ' + name;
+        console.error('No service factory or component factory found for ' + name);
+        console.trace();
     }
 
     getComponentRegistry(): Array<string> {


### PR DESCRIPTION
Module.get() will throw console.error instead of throw ''. Get piped into GetFactory to reduce
redundant code.

Fix #90

